### PR TITLE
makebb: add "generate code but do not build" switch

### DIFF
--- a/src/cmd/makebb/makebb.go
+++ b/src/cmd/makebb/makebb.go
@@ -20,6 +20,7 @@ import (
 var (
 	outputPath = flag.String("o", "bb", "Path to compiled busybox binary")
 	genDir     = flag.String("gen-dir", "", "Directory to generate source in")
+	genOnly    = flag.Bool("g", false, "Generate but do not build binaries")
 )
 
 func main() {
@@ -59,6 +60,7 @@ func main() {
 		CommandPaths: flag.Args(),
 		BinaryPath:   o,
 		GoBuildOpts:  bopts,
+		GenerateOnly: *genOnly,
 	}
 	if err := bb.BuildBusybox(opts); err != nil {
 		l.Print(err)

--- a/src/pkg/bb/bb.go
+++ b/src/pkg/bb/bb.go
@@ -96,6 +96,10 @@ type Opts struct {
 	//
 	// If this is done with GO111MODULE=on,
 	AllowMixedMode bool
+
+	// Generate the tree but don't build it. This is useful for systems
+	// like Tamago which have their own way of building.
+	GenerateOnly bool
 }
 
 // BuildBusybox builds a busybox of many Go commands. opts contains both the
@@ -132,6 +136,9 @@ func BuildBusybox(opts *Opts) (nerr error) {
 		}
 		tmpDir = absDir
 	} else {
+		if opts.GenerateOnly {
+			return fmt.Errorf("generate switch requires that generate directory be supplied")
+		}
 		var err error
 		tmpDir, err = ioutil.TempDir("", "bb-")
 		if err != nil {
@@ -198,6 +205,10 @@ func BuildBusybox(opts *Opts) (nerr error) {
 
 	if err := writeBBMain(bbDir, tmpDir, bbImports); err != nil {
 		return fmt.Errorf("failed to write main.go: %v", err)
+	}
+
+	if opts.GenerateOnly {
+		return nil
 	}
 
 	// Compile bb.


### PR DESCRIPTION
-g will allow the package to generate code but not compile it.

Systems like tamago are not quite in reach for makebb to build just yet.

If the generate directory is empty an error will be returned.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>